### PR TITLE
fixes an issue where logout is throwing "ERROR_HTTP_404"

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -52,6 +52,7 @@ function getSession(request, response) {
 
 function resumeSalesforceConnection(session) {
   return new jsforce.Connection({
+    oauth2: oauth2,
     instanceUrl: session.sfdcAuth.instanceUrl,
     accessToken: session.sfdcAuth.accessToken,
     version: process.env.apiVersion


### PR DESCRIPTION
On scratch orgs and sandboxes, the logout route is throwing an error `ERROR_HTTP_404`... presumably because jsforce uses the default login url of login.salesforce.com but I'm not sure? Adding `oauth2` as a param resolves the issue.